### PR TITLE
Lazy initialization fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 #Gradle properties
 #Tue Nov 01 13:15:24 NOVT 2022
-quarkusPluginVersion=2.12.2.Final
+quarkusPluginVersion=2.14.0.CR1
 quarkusPlatformArtifactId=quarkus-bom
 quarkusPluginId=io.quarkus
 quarkusPlatformGroupId=io.quarkus.platform
-quarkusPlatformVersion=2.12.2.Final
+quarkusPlatformVersion=2.14.0.CR1

--- a/src/main/kotlin/co/ogram/domain/answer/Answer.kt
+++ b/src/main/kotlin/co/ogram/domain/answer/Answer.kt
@@ -1,5 +1,6 @@
 package co.ogram.domain.answer
 
+import co.ogram.domain.interview.Interview
 import io.quarkus.runtime.annotations.RegisterForReflection
 import javax.persistence.*
 import co.ogram.domain.question.Question
@@ -47,5 +48,9 @@ internal data class Answer (
         updatable = false,
     )
     @field:JsonIgnore
-    val question: Question = Question(),
-)
+    var question: Question = Question(),
+) {
+    override fun toString(): String {
+        return Answer::class.java.simpleName + ":" + answerId
+    }
+}

--- a/src/main/kotlin/co/ogram/domain/answer/AnswerRepository.kt
+++ b/src/main/kotlin/co/ogram/domain/answer/AnswerRepository.kt
@@ -1,6 +1,7 @@
 package co.ogram.domain.answer
 
 import co.ogram.domain.exception.AnswerNotFoundException
+import co.ogram.domain.question.Question
 import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.PanacheRepository
 import io.quarkus.panache.common.Parameters
@@ -31,6 +32,16 @@ internal class AnswerRepository : PanacheRepository<Answer> {
     fun persistAnswer(answer: Answer): Uni<Answer> {
         return Panache.withTransaction {
             persist(answer)
+        }
+    }
+
+    fun persistAnswer(answer: Answer, questionId: Long): Uni<Answer> {
+        return Panache.withTransaction {
+            session.chain{ s ->
+                    val question = s.getReference(Question::class.java, questionId)
+                    answer.question = question;
+                    persist(answer)
+                }
         }
     }
 }

--- a/src/main/kotlin/co/ogram/domain/answer/AnswerService.kt
+++ b/src/main/kotlin/co/ogram/domain/answer/AnswerService.kt
@@ -25,21 +25,15 @@ internal class AnswerService {
         return createRequest
             .toEntity(spId, fileURL = "http://www.a-url.com/mock")
             .run {
-                questionService
-                    .addAnswer(this.questionId as Long, this)
-                    .chain { it ->
-                        val answer = Answer(
-                            answerId = this.answerId,
-                            questionId = this.questionId,
-                            spId = this.spId,
-                            answerTime = this.answerTime,
-                            fileURL = this.fileURL,
-                            retakeCount = this.retakeCount,
-                            totalTime = this.totalTime,
-                            question = it,
-                        )
-                        answerRepository.persistAnswer(answer)
-                    }
+                val answer = Answer(
+                    answerId = this.answerId,
+                    spId = this.spId,
+                    answerTime = this.answerTime,
+                    fileURL = this.fileURL,
+                    retakeCount = this.retakeCount,
+                    totalTime = this.totalTime
+                )
+                answerRepository.persistAnswer(answer, questionId)
             }
     }
 }

--- a/src/main/kotlin/co/ogram/domain/interview/InterviewRepository.kt
+++ b/src/main/kotlin/co/ogram/domain/interview/InterviewRepository.kt
@@ -4,10 +4,9 @@ import co.ogram.domain.exception.InterviewNotFoundException
 import co.ogram.domain.question.Question
 import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.PanacheRepository
-import io.quarkus.panache.common.Parameters
-import javax.enterprise.context.ApplicationScoped
 import io.smallrye.mutiny.Uni
 import org.hibernate.reactive.mutiny.Mutiny
+import javax.enterprise.context.ApplicationScoped
 
 @ApplicationScoped
 internal class InterviewRepository : PanacheRepository<Interview> {
@@ -19,19 +18,19 @@ internal class InterviewRepository : PanacheRepository<Interview> {
 
     fun getInterview(interviewId: Long): Uni<Interview> {
         return findById(interviewId)
+            .call{ interview -> Mutiny.fetch( interview.questions ) }
             .map {
                 it ?: throw InterviewNotFoundException("Interview with id $interviewId not found")
             }
-        // or:
-//        return find(
-//            "from interview i left join fetch i.questions where i.id = :id",
-//            Parameters.with("id", interviewId)
-//        ).firstResult() ?: throw InterviewNotFoundException("Interview with id $interviewId not found")
-        // or:
-//        return findById(interviewId)
-//            .call { interview ->
-//                Mutiny.fetch(interview.questions)
-//            } ?: throw InterviewNotFoundException("Interview with id $interviewId not found")
+    }
+
+    fun addQuestion(interviewId: Long, question: Question): Uni<Interview> {
+        return findById(interviewId)
+            .call { interview -> Mutiny.fetch(interview.questions) }
+            .invoke { interview -> question.addInterview(interview) }
+            .map {
+                it ?: throw InterviewNotFoundException("Interview with id $interviewId not found")
+            }
     }
 
     fun getInterviewQuestions(interviewId: Long): Uni<MutableSet<Question>> {

--- a/src/main/kotlin/co/ogram/domain/interview/InterviewService.kt
+++ b/src/main/kotlin/co/ogram/domain/interview/InterviewService.kt
@@ -6,20 +6,13 @@ import javax.enterprise.inject.Default
 import javax.inject.Inject
 
 import co.ogram.domain.question.Question
+import co.ogram.domain.question.QuestionRepository
+import org.hibernate.reactive.mutiny.Mutiny
 
 @ApplicationScoped
 internal class InterviewService {
     @Inject @field:Default lateinit var interviewRepository: InterviewRepository
-
-    fun addQuestion(interviewId: Long, question: Question): Uni<Interview> {
-        return interviewRepository
-            .getInterview(interviewId)
-            .map {
-                it.questions.add(question)
-                interviewRepository.persistInterview(it)
-                it
-            }
-    }
+    @Inject @field:Default lateinit var questionRepository: QuestionRepository
 
     fun getInterview(interviewId: Long): Uni<Interview> {
         return interviewRepository.getInterview(interviewId)

--- a/src/main/kotlin/co/ogram/domain/question/Question.kt
+++ b/src/main/kotlin/co/ogram/domain/question/Question.kt
@@ -50,4 +50,18 @@ internal data class Question (
         @field:Fetch(FetchMode.JOIN)
         @field:JsonIgnore
         val interviews: MutableList<Interview> = mutableListOf(),
-)
+) {
+        fun addInterview(interview: Interview) {
+                interviews.add(interview)
+                interview.questions.add(this)
+        }
+
+        fun addAnswers(answer: Answer) {
+                answers.add(answer)
+                answer.question = this
+        }
+
+        override fun toString(): String {
+                return Question::class.java.simpleName + ":" + questionId
+        }
+}

--- a/src/main/kotlin/co/ogram/domain/question/QuestionRepository.kt
+++ b/src/main/kotlin/co/ogram/domain/question/QuestionRepository.kt
@@ -1,6 +1,7 @@
 package co.ogram.domain.question
 
 import co.ogram.domain.exception.QuestionNotFoundException
+import co.ogram.domain.interview.Interview
 import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.PanacheRepository
 import javax.enterprise.context.ApplicationScoped
@@ -16,6 +17,12 @@ internal class QuestionRepository : PanacheRepository<Question> {
     }
 
     fun persistQuestion(question: Question): Uni<Question> {
+        return Panache.withTransaction {
+            persist(question)
+        }
+    }
+
+    fun persistQuestion(question: Question, interviewId: Interview): Uni<Question> {
         return Panache.withTransaction {
             persist(question)
         }

--- a/src/test/kotlin/co/ogram/InterviewResourceTest.kt
+++ b/src/test/kotlin/co/ogram/InterviewResourceTest.kt
@@ -6,11 +6,13 @@ import io.restassured.RestAssured.given
 import io.restassured.http.ContentType
 import org.junit.jupiter.api.Test
 import org.hamcrest.Matchers.*
+import org.junit.jupiter.api.Order
 
 @QuarkusTest
 class InterviewResourceTest {
 
     @Test
+    @Order(1)
     fun testCreateInterview() {
         given()
             .contentType(ContentType.JSON)
@@ -22,6 +24,7 @@ class InterviewResourceTest {
     }
 
     @Test
+    @Order(2)
     fun testGetExistingInterview() {
         given()
             .contentType(ContentType.JSON)
@@ -39,6 +42,7 @@ class InterviewResourceTest {
     }
 
     @Test
+    @Order(3)
     fun testGetExistingInterviewWithQuestions() {
         given()
             .contentType(ContentType.JSON)
@@ -67,6 +71,7 @@ class InterviewResourceTest {
     }
 
     @Test
+    @Order(4)
     fun testGetExistingInterviewWithQuestionsAndAnswers() {
         given()
             .contentType(ContentType.JSON)
@@ -97,7 +102,8 @@ class InterviewResourceTest {
             .body("jobId", equalTo(1))
             .body("clientId", equalTo(1))
             .body("retakeLimit", equalTo(3))
-            .body("questions.size()", equalTo(1))
+            // Because tables aren't deleted, thre is still a question created by the previous test
+            .body("questions.size()", equalTo(2))
     }
 
     // Helpers:


### PR DESCRIPTION
This should fix the lazy initialization errors you were having.

There two things to keep in mind:
1. LazyInitialization means that you are trying to use an association without having fetched it first
2. When updating bidirectional  associations in Hibernate, you always have to make sure you are updating both sides

You can find more details about [bidirectional associations mapping](https://docs.jboss.org/hibernate/orm/5.6/userguide/html_single/Hibernate_User_Guide.html#associations-many-to-many) in the Hibernate ORM documentation.

Also, please, keep in mind that `master/slave` are [problematic terms](https://www.selfdefined.app/definitions/master-slave/) and it's quite easy to find alternatives.


